### PR TITLE
updated serializers to show all project details

### DIFF
--- a/workflowapiapi/views/project.py
+++ b/workflowapiapi/views/project.py
@@ -1,12 +1,17 @@
 from rest_framework import viewsets, serializers
 from workflowapiapi.models import Project
+from .client import ClientSerializer
+from .project_group import ProjectGroupReadSerializer
 
 class ProjectSerializer(serializers.ModelSerializer):
+    client = ClientSerializer()  
+    projectgroup_set =  ProjectGroupReadSerializer(many=True, read_only=True) 
+
     class Meta:
         model = Project
         fields = ['id', 'client', 'name', 'status', 'start_date', 'end_date', 
-                 'expected_duration']
-
+                 'expected_duration', 'projectgroup_set']
+        
 class ProjectViewSet(viewsets.ModelViewSet):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer

--- a/workflowapiapi/views/project_group.py
+++ b/workflowapiapi/views/project_group.py
@@ -1,11 +1,23 @@
 from rest_framework import viewsets, serializers
 from workflowapiapi.models import ProjectGroup
+from .group import GroupSerializer
+
+class ProjectGroupReadSerializer(serializers.ModelSerializer):
+    group = GroupSerializer()
+    
+    class Meta:
+        model = ProjectGroup
+        fields = ['id', 'group', 'project']
 
 class ProjectGroupSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProjectGroup
         fields = ['id', 'group', 'project']
-
+        
 class ProjectGroupViewSet(viewsets.ModelViewSet):
     queryset = ProjectGroup.objects.all()
-    serializer_class = ProjectGroupSerializer
+    
+    def get_serializer_class(self):
+        if self.action in ['list', 'retrieve']:  # When reading data
+            return ProjectGroupReadSerializer
+        return ProjectGroupSerializer


### PR DESCRIPTION
changed the serializers so that when an API is made to the projects, I will get all the information about the project instead of just getting IDs for the group and client, I now get the information about them. 